### PR TITLE
Simplify is_from_game()

### DIFF
--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -5,25 +5,6 @@ require_once __DIR__ . '/../queries/tokens/token_delete.php';
 
 header("Content-type: text/plain");
 
-function is_from_game(){
- if (isset($_SERVER["HTTP_X_REQUESTED_WITH"]) && !empty($_SERVER["HTTP_X_REQUESTED_WITH"])){
-  if (!isset($_SERVER["HTTP_REFERER"]) || $_SERVER["HTTP_REFERER"] === ""){
-   return true;
-  }
-  if (strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0){
-   return true;
-  }
-     else
-  {
-      return false;   
-  }
- }
- else
- {
-    return false;
- }
-}
-
 $ip = get_ip();
 
 try {
@@ -50,4 +31,17 @@ try {
 } catch (Exception $e) {
     $error = $e->getMessage();
     echo "error=$error";
+}
+
+function is_from_game() 
+{
+    $is_from_game = false;
+    
+    if ((!is_empty($_SERVER["HTTP_X_REQUESTED_WITH"]) &&
+        strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0) ||
+        is_empty($_SERVER["HTTP_REFERER"])) {
+        $is_from_game = true;
+    }
+    
+    return $is_from_game;
 }

--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -37,10 +37,14 @@ function is_from_game()
 {
     $is_from_game = false;
     
-    if ((!is_empty($_SERVER["HTTP_X_REQUESTED_WITH"]) &&
-        strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0) ||
-        is_empty($_SERVER["HTTP_REFERER"])) {
-        $is_from_game = true;
+    if (
+           (
+           !is_empty($_SERVER["HTTP_X_REQUESTED_WITH"]) &&
+           strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0
+           ) ||
+       is_empty($_SERVER["HTTP_REFERER"])
+    ) {
+         $is_from_game = true;
     }
     
     return $is_from_game;

--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -35,15 +35,11 @@ try {
 
 function is_from_game() 
 {
+    $req_with = $_SERVER["HTTP_X_REQUESTED_WITH"];
+    $ref = $_SERVER["HTTP_REFERER"];
     $is_from_game = false;
     
-    if (
-           (
-           !is_empty($_SERVER["HTTP_X_REQUESTED_WITH"]) &&
-           strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0
-           ) ||
-       is_empty($_SERVER["HTTP_REFERER"])
-    ) {
+    if ((!is_empty($req_with) && strpos($req_with, "ShockwaveFlash/") !== 0) || is_empty($ref)) {
          $is_from_game = true;
     }
     


### PR DESCRIPTION
There's really no way to avoid this monstrosity of a line while keeping PSR-2 compliance without breaking it into a few lines.  Additionally, doing it all in one if statement is more efficient when both versions of the code would put the lines over 80 characters per line anyway.

Also, removed some unnecessary if/else blocks and consolidated our return boolean into one variable.